### PR TITLE
Add support for WSL 2

### DIFF
--- a/wsl_path_converter/__init__.py
+++ b/wsl_path_converter/__init__.py
@@ -72,7 +72,7 @@ def parse_mounts():
         for line in fd.read().splitlines():
             source, target, type_, _ = line.split(b" ", 3)
             
-            if type_ != b"drvfs":
+            if type_ not in (b"drvfs", b"9p"):
                 continue
             
             # Decode the string (backslash-escaped octal values)


### PR DESCRIPTION
Currently the path conversion does not work on WSL 2:

```
import wsl_path_converter
print(wsl_path_converter.convert_u("C:\\Windows\\System32\\cmd.exe"))
```

> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File "/home/user/.local/lib/python3.8/site-packages/wsl_path_converter/__init__.py", line 28, in convert_u
>     windows_root = find_root(linux_roots, windows_path, "\\")
>   File "/home/user/.local/lib/python3.8/site-packages/wsl_path_converter/__init__.py", line 97, in find_root
>     raise Exception("No root found for {}".format(path))
> Exception: No root found for C:\Windows\System32\cmd.exe


The cause of the error is, that the format of the file /proc/mounts changes between WSL1 and WSL2:

`cat /proc/mounts | grep drvfs`

WSL 1
> C: /mnt/c drvfs rw,noatime,uid=1000,gid=1000,case=off 0 0

WSL 2
> C:\134 /mnt/c 9p rw,dirsync,noatime,aname=drvfs;path=C:\;uid=1000;gid=1000;symlinkroot=/mnt/,mmap,access=client,msize=65536,trans=fd,rfd=8,wfd=8 0 0

In WSL 2, the type is not drvfs but 9p. I have tested the file /proc/mounts on Ubuntu, Debian, Kali, Alpine and SUSE, and it is the same across distros.

Support for WSL 2 can then be added with the following change:

```
         for line in fd.read().splitlines():
             source, target, type_, _ = line.split(b" ", 3)

-            if type_ != b"drvfs":
+            if type_ not in (b"drvfs", b"9p"):
                 continue

             # Decode the string (backslash-escaped octal values)
```

After the change:

```
import wsl_path_converter
print(wsl_path_converter.convert_u("C:\\Windows\\System32\\cmd.exe"))
```

> /mnt/c/Windows/System32/cmd.exe

